### PR TITLE
Feat/outbox

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
 
     // Kafka test
     testImplementation "org.testcontainers:kafka"
+
+    implementation "com.vladmihalcea:hibernate-types-60:2.20.0"
 }
 
 // querydsl generated 경로 설정

--- a/src/main/java/io/dami/market/application/payment/PayCompleteEvent.java
+++ b/src/main/java/io/dami/market/application/payment/PayCompleteEvent.java
@@ -1,6 +1,6 @@
 package io.dami.market.application.payment;
 
-public record PaymentCompleteEvent(
+public record PayCompleteEvent(
     Long orderId,
     Long paymentId
 ) {

--- a/src/main/java/io/dami/market/application/payment/PaymentEventListener.java
+++ b/src/main/java/io/dami/market/application/payment/PaymentEventListener.java
@@ -1,0 +1,41 @@
+package io.dami.market.application.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
+import io.dami.market.domain.payment.event.PaymentEventPublisher;
+import io.dami.market.domain.payment.outbox.PaymentOutbox;
+import io.dami.market.domain.payment.outbox.PaymentOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+  private final PaymentEventPublisher paymentEventPublisher;
+  private final PaymentOutboxRepository paymentOutboxRepository;
+  private final ObjectMapper objectMapper;
+
+  @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+  public void saveOutBox(PayCompleteEvent event) {
+    try {
+      paymentOutboxRepository.savePaymentOutbox(
+          PaymentOutbox.create(objectMapper.writeValueAsString(event)));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void sendOrderPaymentData(PayCompleteEvent event) {
+    paymentEventPublisher.sendMessage(event);
+  }
+
+}

--- a/src/main/java/io/dami/market/application/payment/PaymentFacade.java
+++ b/src/main/java/io/dami/market/application/payment/PaymentFacade.java
@@ -4,6 +4,7 @@ import io.dami.market.domain.order.Order;
 import io.dami.market.domain.order.OrderService;
 import io.dami.market.domain.payment.Payment;
 import io.dami.market.domain.payment.PaymentService;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
 import io.dami.market.domain.point.PointService;
 import io.dami.market.domain.product.ProductService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/io/dami/market/application/payment/PaymentFacade.java
+++ b/src/main/java/io/dami/market/application/payment/PaymentFacade.java
@@ -27,6 +27,6 @@ public class PaymentFacade {
     productService.quantitySubtract(order.getProductQuantityMap());
     Payment payment = paymentService.pay(orderId, order.getTotalAmount());
     pointService.usePoints(userId, payment.getTotalAmount());
-    eventPublisher.publishEvent(new PaymentCompleteEvent(orderId, payment.getId()));
+    eventPublisher.publishEvent(new PayCompleteEvent(orderId, payment.getId()));
   }
 }

--- a/src/main/java/io/dami/market/domain/payment/event/PayCompleteEvent.java
+++ b/src/main/java/io/dami/market/domain/payment/event/PayCompleteEvent.java
@@ -1,4 +1,4 @@
-package io.dami.market.application.payment;
+package io.dami.market.domain.payment.event;
 
 public record PayCompleteEvent(
     Long orderId,

--- a/src/main/java/io/dami/market/domain/payment/event/PaymentEventPublisher.java
+++ b/src/main/java/io/dami/market/domain/payment/event/PaymentEventPublisher.java
@@ -1,0 +1,6 @@
+package io.dami.market.domain.payment.event;
+
+public interface PaymentEventPublisher {
+
+  void sendMessage(PayCompleteEvent event);
+}

--- a/src/main/java/io/dami/market/domain/payment/outbox/PaymentOutbox.java
+++ b/src/main/java/io/dami/market/domain/payment/outbox/PaymentOutbox.java
@@ -1,0 +1,54 @@
+package io.dami.market.domain.payment.outbox;
+
+import io.dami.market.domain.Auditor;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@Table(name = "payment_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentOutbox extends Auditor {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Comment(value = "고유 아이디")
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "payload")
+  private String payload;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", columnDefinition = "varchar(255)")
+  private PaymentOutboxStatus status;
+
+  public static PaymentOutbox create(String payload) {
+    return PaymentOutbox.builder()
+        .payload(payload)
+        .status(PaymentOutboxStatus.INIT)
+        .build();
+  }
+
+  public void changeStatus(PaymentOutboxStatus paymentOutboxStatus) {
+    this.status = paymentOutboxStatus;
+  }
+
+  public enum PaymentOutboxStatus {
+    INIT, SUCCESS, FAIL
+  }
+}

--- a/src/main/java/io/dami/market/domain/payment/outbox/PaymentOutboxRepository.java
+++ b/src/main/java/io/dami/market/domain/payment/outbox/PaymentOutboxRepository.java
@@ -1,0 +1,13 @@
+package io.dami.market.domain.payment.outbox;
+
+
+import java.util.List;
+
+public interface PaymentOutboxRepository {
+
+  PaymentOutbox savePaymentOutbox(PaymentOutbox paymentOutbox);
+
+  PaymentOutbox getByPayload(String message);
+
+  List<PaymentOutbox> getReissueOutboxes();
+}

--- a/src/main/java/io/dami/market/domain/payment/outbox/PaymentOutboxService.java
+++ b/src/main/java/io/dami/market/domain/payment/outbox/PaymentOutboxService.java
@@ -1,0 +1,19 @@
+package io.dami.market.domain.payment.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentOutboxService {
+
+  private final PaymentOutboxRepository paymentOutboxRepository;
+
+
+  @Transactional(readOnly = true)
+  public PaymentOutbox getByPayload(String payload) {
+    return paymentOutboxRepository.getByPayload(payload);
+  }
+
+}

--- a/src/main/java/io/dami/market/infra/dataplatform/DataPlatformService.java
+++ b/src/main/java/io/dami/market/infra/dataplatform/DataPlatformService.java
@@ -1,6 +1,6 @@
 package io.dami.market.infra.dataplatform;
 
-import io.dami.market.application.payment.PayCompleteEvent;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
 import org.springframework.stereotype.Component;
 
 /**

--- a/src/main/java/io/dami/market/infra/dataplatform/DataPlatformService.java
+++ b/src/main/java/io/dami/market/infra/dataplatform/DataPlatformService.java
@@ -1,15 +1,15 @@
 package io.dami.market.infra.dataplatform;
 
-import io.dami.market.application.payment.PaymentCompleteEvent;
+import io.dami.market.application.payment.PayCompleteEvent;
 import org.springframework.stereotype.Component;
 
 /**
  * 데이터 플랫폼
  */
 @Component
-public interface DataPlatform {
+public interface DataPlatformService {
 
   // 주문 정보 전송
-  void publish(PaymentCompleteEvent event);
+  void sendOrderPaymentData(PayCompleteEvent event);
 
 }

--- a/src/main/java/io/dami/market/infra/dataplatform/DataPlatformServiceServiceImpl.java
+++ b/src/main/java/io/dami/market/infra/dataplatform/DataPlatformServiceServiceImpl.java
@@ -1,6 +1,6 @@
 package io.dami.market.infra.dataplatform;
 
-import io.dami.market.application.payment.PaymentCompleteEvent;
+import io.dami.market.application.payment.PayCompleteEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -12,13 +12,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
  */
 @Slf4j
 @Component
-public class DataPlatformImpl implements DataPlatform {
+public class DataPlatformServiceServiceImpl implements DataPlatformService {
 
   // 주문 정보 전송
   @Override
   @Async
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-  public void publish(PaymentCompleteEvent event) {
+  public void sendOrderPaymentData(PayCompleteEvent event) {
     log.info("Publishing to Mock Data Platform. Order ID: {}, Payment ID: {}", event.orderId(),
         event.paymentId());
   }

--- a/src/main/java/io/dami/market/infra/dataplatform/DataPlatformServiceServiceImpl.java
+++ b/src/main/java/io/dami/market/infra/dataplatform/DataPlatformServiceServiceImpl.java
@@ -1,23 +1,20 @@
 package io.dami.market.infra.dataplatform;
 
-import io.dami.market.application.payment.PayCompleteEvent;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
  * 데이터 플랫폼
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class DataPlatformServiceServiceImpl implements DataPlatformService {
 
   // 주문 정보 전송
   @Override
-  @Async
-  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void sendOrderPaymentData(PayCompleteEvent event) {
     log.info("Publishing to Mock Data Platform. Order ID: {}, Payment ID: {}", event.orderId(),
         event.paymentId());

--- a/src/main/java/io/dami/market/infra/dummy/LocalDummyData.java
+++ b/src/main/java/io/dami/market/infra/dummy/LocalDummyData.java
@@ -15,8 +15,6 @@ import io.dami.market.domain.user.User;
 import io.dami.market.domain.user.UserRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
@@ -42,7 +40,7 @@ public class LocalDummyData {
   public void init() {
     if (initDummy) {
 
-      int userCount = 500;
+      int userCount = 1;
 
       couponRepository.save(Coupon.builder()
           .name("선착순쿠폰")
@@ -52,18 +50,12 @@ public class LocalDummyData {
           .totalQuantity(500)
           .build());
 
-      for (int i = 0; i < 100000; i++) {
+      for (int i = 0; i < 100; i++) {
         productRepository.save(Product.builder()
             .name("product " + i)
             .price(new BigDecimal("1000"))
             .stockQuantity(1000)
             .build());
-      }
-
-      List<Product> products = new ArrayList<>();
-      for (Long i = 1L; i <= 100000; i++) {
-        Product product = productRepository.getProduct(i);
-        products.add(product);
       }
 
       for (int i = 1; i <= userCount; i++) {
@@ -72,7 +64,7 @@ public class LocalDummyData {
             .build());
 
         pointRepository.save(Point.builder()
-            .totalPoint(new BigDecimal("100000"))
+            .totalPoint(new BigDecimal("1000000"))
             .userId(user.getId())
             .build());
 
@@ -89,23 +81,22 @@ public class LocalDummyData {
         Order order = orderRepository.save(Order.builder()
             .userId(user.getId())
             .issuedCouponId(null)
-            .status(
-                user.getId() % 2 == 0 ? OrderStatus.ORDER_COMPLETE : OrderStatus.ORDER_CANCELLED)
+            .status(OrderStatus.ORDER_COMPLETE)
             .build());
 
         int count = 0;
-        while (true) {
-          Long productIndex = (long) (Math.random() * 100000);
+
+        for (long j = 1L; j < 10L; j++) {
+          Long productIndex = j;
           if (count == 5) {
             break;
           }
           count++;
           order.addOrderDetail(
-              OrderDetail.createOrderDetail(order, productIndex, (int) (Math.random() * 1001),
+              OrderDetail.createOrderDetail(order, productIndex, 10,
                   new BigDecimal("3000")));
         }
       }
     }
   }
-
 }

--- a/src/main/java/io/dami/market/infra/payment/PaymentPublisherImpl.java
+++ b/src/main/java/io/dami/market/infra/payment/PaymentPublisherImpl.java
@@ -1,0 +1,32 @@
+package io.dami.market.infra.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
+import io.dami.market.domain.payment.event.PaymentEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * kafkaTemplate 활용한 Topic 내에 메시지를 전송하는 다양한 방법
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentPublisherImpl implements PaymentEventPublisher {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final String TOPIC_NAME = "order-payment";
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void sendMessage(PayCompleteEvent event) {
+    try {
+      kafkaTemplate.send(TOPIC_NAME, objectMapper.writeValueAsString(event));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/io/dami/market/infra/payment/outbox/PaymentOutboxJpaRepository.java
+++ b/src/main/java/io/dami/market/infra/payment/outbox/PaymentOutboxJpaRepository.java
@@ -1,0 +1,24 @@
+package io.dami.market.infra.payment.outbox;
+
+import io.dami.market.domain.payment.outbox.PaymentOutbox;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PaymentOutboxJpaRepository extends JpaRepository<PaymentOutbox, Long> {
+
+  @Query("""
+      select pob
+      from PaymentOutbox pob
+      where pob.payload = :payload
+      """)
+  Optional<PaymentOutbox> findByPayload(String payload);
+
+  @Query("""
+      select pob
+      from PaymentOutbox pob
+      where pob.status != 'SUCCESS'
+      """)
+  List<PaymentOutbox> getReissueOutboxes();
+}

--- a/src/main/java/io/dami/market/infra/payment/outbox/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/io/dami/market/infra/payment/outbox/PaymentOutboxRepositoryImpl.java
@@ -1,0 +1,32 @@
+package io.dami.market.infra.payment.outbox;
+
+import io.dami.market.domain.payment.outbox.PaymentOutbox;
+import io.dami.market.domain.payment.outbox.PaymentOutboxRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
+
+  private final PaymentOutboxJpaRepository paymentOutboxJpaRepository;
+
+  @Override
+  public PaymentOutbox savePaymentOutbox(PaymentOutbox paymentOutbox) {
+    return paymentOutboxJpaRepository.save(paymentOutbox);
+  }
+
+  @Override
+  public PaymentOutbox getByPayload(String payload) {
+    return paymentOutboxJpaRepository.findByPayload(payload)
+        .orElseThrow(EntityNotFoundException::new);
+  }
+
+  @Override
+  public List<PaymentOutbox> getReissueOutboxes() {
+    return paymentOutboxJpaRepository.getReissueOutboxes();
+  }
+
+}

--- a/src/main/java/io/dami/market/interfaces/payment/PaymentConsumer.java
+++ b/src/main/java/io/dami/market/interfaces/payment/PaymentConsumer.java
@@ -1,0 +1,43 @@
+package io.dami.market.interfaces.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
+import io.dami.market.domain.payment.outbox.PaymentOutbox;
+import io.dami.market.domain.payment.outbox.PaymentOutbox.PaymentOutboxStatus;
+import io.dami.market.domain.payment.outbox.PaymentOutboxService;
+import io.dami.market.infra.dataplatform.DataPlatformService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentConsumer {
+
+  private final String TOPIC_NAME = "order-payment";
+  private final ObjectMapper objectMapper;
+  private final PaymentOutboxService paymentOutboxService;
+  private final DataPlatformService dataPlatformService;
+
+  @KafkaListener(topics = TOPIC_NAME, groupId = "group-1")
+  @Transactional
+  public void sendDataPlatform(String payload) throws JsonProcessingException {
+    log.info("메시지 수신: {}", payload);
+
+    PaymentOutbox paymentOutbox = paymentOutboxService.getByPayload(payload);
+
+    if (paymentOutbox.getStatus() == PaymentOutbox.PaymentOutboxStatus.SUCCESS) {
+      return;
+    }
+
+    PayCompleteEvent payCompleteEvent = objectMapper.readValue(payload, PayCompleteEvent.class);
+    paymentOutbox.changeStatus(PaymentOutboxStatus.FAIL);
+    dataPlatformService.sendOrderPaymentData(payCompleteEvent);
+    paymentOutbox.changeStatus(PaymentOutboxStatus.SUCCESS);
+  }
+
+}

--- a/src/main/java/io/dami/market/interfaces/payment/PaymentOutboxScheduler.java
+++ b/src/main/java/io/dami/market/interfaces/payment/PaymentOutboxScheduler.java
@@ -1,0 +1,30 @@
+package io.dami.market.interfaces.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dami.market.domain.payment.event.PayCompleteEvent;
+import io.dami.market.domain.payment.event.PaymentEventPublisher;
+import io.dami.market.domain.payment.outbox.PaymentOutbox;
+import io.dami.market.domain.payment.outbox.PaymentOutboxRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentOutboxScheduler {
+
+  private final PaymentOutboxRepository paymentOutboxRepository;
+  private final PaymentEventPublisher paymentEventPublisher;
+  private final ObjectMapper objectMapper;
+
+  @Scheduled(fixedRate = 10000)
+  public void paymentOutboxReissue() throws JsonProcessingException {
+    List<PaymentOutbox> paymentOutboxes = paymentOutboxRepository.getReissueOutboxes();
+    for (PaymentOutbox paymentOutbox : paymentOutboxes) {
+      paymentEventPublisher.sendMessage(objectMapper.readValue(paymentOutbox.getPayload(),
+          PayCompleteEvent.class));
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
     password: 1234
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
@@ -59,4 +59,4 @@ logging:
     root: info
     org.hibernate.orm.jdbc.bind: trace
 
-dummy-data: false
+dummy-data: true


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->
데이터 플랫폼 Transactional Outbox Pattern 적용 & 실패 재처리 Scheduler 구현: b1d5dd192ab9fa1a30e2e72736224fb85b4a8f46
---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
(`PaymentOutboxScheduler.java`)스케줄러의 실패 테스트는 애플리케이션을 실행한 후 
 따로 DB에 직접 값을 넣어 테스트 했는데요, 실무에서 스케줄러만을 따로 테스트 하는 방법이 있다면 조언 부탁드리겠습니다.
- 리뷰 포인트 2
1번 질문과 마찬가지로 카프카의 데이터 플랫폼 전송 로직을 기존에 있던 (`PaymentFacadeIntegrationTest.java`) 의 결제 파사드 테스트로 진행한 후 콘솔 로그를 확인해서 카프카 컨슈머가 정상적으로 동작했다는 것을 확인하였는데요, 이런 식으로 데이터 플랫폼 전송 기능의 카프카 로직만을 따로 검증할 수 있는 방법이 있다면 조언 부탁드리겠습니다.
감사합니다.
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
